### PR TITLE
MEA-1206 using 10.16 node version for circle CI builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/currency-flags
   docker:
-    - image: circleci/node:latest
+    - image: circleci/node:10.16
 
 version: 2
 jobs:


### PR DESCRIPTION
using production node version for circle config, instead of circleci/node:latest (public container)