### PR TITLE
Update Readme with published package path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package outputs two CSS files (minified and unminified) with classes for cu
 
 **1. Install**
 
-`npm install --save https://github.com/transferwise/currency-flags.git`
+`npm install --save currency-flags`
 
 **2. Add CSS to page**
 


### PR DESCRIPTION
Updated installation instructions linking to [published package on NPM](https://www.npmjs.com/package/currency-flags), reducing the install size.