### PR TITLE
Add alias for CNH currency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currency-flags",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Flags for currency codes.",
   "files": [
     "dist/currency-flags.css",

--- a/src/styles.css
+++ b/src/styles.css
@@ -49,6 +49,7 @@
 .currency-flag.currency-flag-cdf{background-image:url('https://transferwise.com/public-resources/assets/flags/rectangle/cdf.png');}
 .currency-flag.currency-flag-chf{background-image:url('https://transferwise.com/public-resources/assets/flags/rectangle/chf.png');}
 .currency-flag.currency-flag-clp{background-image:url('https://transferwise.com/public-resources/assets/flags/rectangle/clp.png');}
+.currency-flag.currency-flag-cnh,
 .currency-flag.currency-flag-cny{background-image:url('https://transferwise.com/public-resources/assets/flags/rectangle/cny.png');}
 .currency-flag.currency-flag-cop{background-image:url('https://transferwise.com/public-resources/assets/flags/rectangle/cop.png');}
 .currency-flag.currency-flag-crc{background-image:url('https://transferwise.com/public-resources/assets/flags/rectangle/crc.png');}
@@ -171,4 +172,3 @@
 .currency-flag.currency-flag-yer{background-image:url('https://transferwise.com/public-resources/assets/flags/rectangle/yer.png');}
 .currency-flag.currency-flag-zar{background-image:url('https://transferwise.com/public-resources/assets/flags/rectangle/zar.png');}
 .currency-flag.currency-flag-zmw{background-image:url('https://transferwise.com/public-resources/assets/flags/rectangle/zmw.png');}
-


### PR DESCRIPTION
## Context

The currency of PRC (Renminbi) has two different currency codes - one for mainland China (CNY) and one for offshore banking (CNH). The latter does not have a flag, even if it is an active currency.

### Changes

I propose simply adding a CSS selector to point this currency code to the regular PRC flag.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
